### PR TITLE
fix: use MINISIGN_PASSPHRASE secret for password-protected keys

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,13 +85,10 @@ jobs:
       - name: Sign package with minisign
         run: |
           if [ ! -f minisign.key.skip ]; then
-            # Try to sign, but don't fail if key requires password
-            if minisign -Sm "$PACKAGE_FILE" -s minisign.key -t "create-claude npm package v$VERSION - $(date -u +%Y-%m-%d)" 2>/dev/null; then
-              echo "✓ Successfully signed package with minisign"
-            else
-              echo "::warning::Minisign signing failed (key may require password). Continuing without minisign signature."
-              touch minisign.key.skip
-            fi
+            # Use MINISIGN_PASSPHRASE environment variable for the password
+            export MINISIGN_ASK_PASS=0
+            echo "${{ secrets.MINISIGN_PASSPHRASE }}" | minisign -Sm "$PACKAGE_FILE" -s minisign.key -t "create-claude npm package v$VERSION - $(date -u +%Y-%m-%d)"
+            echo "✓ Successfully signed package with minisign"
           else
             echo "::warning::Skipping minisign signature generation"
           fi
@@ -140,7 +137,7 @@ jobs:
             if [ -f "$sbom" ]; then
               echo "Signing $sbom"
               if [ ! -f minisign.key.skip ]; then
-                minisign -Sm "$sbom" -s minisign.key -t "SBOM for create-claude v$VERSION"
+                echo "${{ secrets.MINISIGN_PASSPHRASE }}" | minisign -Sm "$sbom" -s minisign.key -t "SBOM for create-claude v$VERSION"
               fi
               gpg --armor --detach-sign --output "$sbom.asc" "$sbom"
             fi
@@ -148,7 +145,7 @@ jobs:
           
           # Find and sign any GitHub attestation files
           if [ ! -f minisign.key.skip ]; then
-            find . -name "*.intoto.jsonl" -exec minisign -Sm {} -s minisign.key -t "SLSA Attestation for create-claude v$VERSION" \;
+            find . -name "*.intoto.jsonl" -exec sh -c 'echo "${{ secrets.MINISIGN_PASSPHRASE }}" | minisign -Sm "$1" -s minisign.key -t "SLSA Attestation for create-claude v$VERSION"' _ {} \;
           fi
           find . -name "*.intoto.jsonl" -exec gpg --armor --detach-sign --output {}.asc {} \;
           


### PR DESCRIPTION
## Summary

Fixes the publish workflow to properly handle password-protected minisign keys using the `MINISIGN_PASSPHRASE` secret.

## Problem

The workflow was failing with `Password: get_password()` error because the minisign private key is password-protected and the workflow couldn't provide the password in a non-interactive CI environment.

## Solution

- Pipe the `MINISIGN_PASSPHRASE` secret to minisign for all signing operations
- Set `MINISIGN_ASK_PASS=0` to prevent interactive password prompts
- Updated both package signing and SBOM/attestation signing steps

## Required Secrets

The workflow now requires:
- `MINISIGN_PRIVATE_KEY`: Base64-encoded minisign private key
- `MINISIGN_PASSPHRASE`: Password for the minisign key (plain text)

## Testing

With both secrets configured, the workflow will:
- Successfully unlock the password-protected key
- Generate minisign signatures for all artifacts
- Complete the release process without errors