### PR TITLE
fix: split SBOM generation into separate steps for each format

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,12 +107,26 @@ jobs:
         with:
           subject-path: ${{ env.PACKAGE_FILE }}
           
-      - name: Generate comprehensive SBOMs with Syft
+      - name: Generate SPDX JSON SBOM
         uses: anchore/sbom-action@e11c554f704a0b820cbf8c51673f6945e0731532 # v0.20.0
         with:
           path: .
-          format: 'spdx-json,cyclonedx-json,cyclonedx-xml'
-          output-file: 'create-claude-${{ env.VERSION }}.sbom'
+          format: 'spdx-json'
+          output-file: 'create-claude-${{ env.VERSION }}.sbom.spdx.json'
+          
+      - name: Generate CycloneDX JSON SBOM
+        uses: anchore/sbom-action@e11c554f704a0b820cbf8c51673f6945e0731532 # v0.20.0
+        with:
+          path: .
+          format: 'cyclonedx-json'
+          output-file: 'create-claude-${{ env.VERSION }}.sbom.cyclonedx.json'
+          
+      - name: Generate CycloneDX XML SBOM
+        uses: anchore/sbom-action@e11c554f704a0b820cbf8c51673f6945e0731532 # v0.20.0
+        with:
+          path: .
+          format: 'cyclonedx-xml'
+          output-file: 'create-claude-${{ env.VERSION }}.sbom.cyclonedx.xml'
           
       - name: Generate legacy SPDX with Microsoft tool
         run: |


### PR DESCRIPTION
## Summary
- Split SBOM generation into three separate steps
- Generate SPDX JSON, CycloneDX JSON, and CycloneDX XML independently
- Fix workflow failure caused by unsupported comma-separated format string

## Problem
The workflow was failing with:
```
ERROR 1 error occurred:
* unsupported output format "spdx-json,cyclonedx-json,cyclonedx-xml"
```

Syft v1.24.0 doesn't support comma-separated multiple output formats in a single command.

## Solution
Run the anchore/sbom-action three times, once for each format:
1. SPDX JSON → `create-claude-VERSION.sbom.spdx.json`
2. CycloneDX JSON → `create-claude-VERSION.sbom.cyclonedx.json`
3. CycloneDX XML → `create-claude-VERSION.sbom.cyclonedx.xml`

## Testing
This fix ensures all three SBOM formats are generated correctly and the workflow completes successfully.