### PR TITLE
fix: update Microsoft SBOM tool to v4.1.1 with correct checksum

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,9 +131,9 @@ jobs:
       - name: Generate legacy SPDX with Microsoft tool
         run: |
           # Download and verify Microsoft SBOM tool
-          curl -LO https://github.com/microsoft/sbom-tool/releases/download/v4.1.2/sbom-tool-linux-x64
-          # Verify against known checksum (Microsoft doesn't provide .sha256 files)
-          echo "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5  sbom-tool-linux-x64" | sha256sum -c
+          curl -LO https://github.com/microsoft/sbom-tool/releases/download/v4.1.1/sbom-tool-linux-x64
+          # Verify against known checksum for v4.1.1
+          echo "7bfda808152651c4af8a223697c2219dc762b5dce2e78cbcc024997b6b1f6833  sbom-tool-linux-x64" | sha256sum -c
           chmod +x sbom-tool-linux-x64
           
           # Generate Microsoft SBOM


### PR DESCRIPTION
## Summary
- Update Microsoft SBOM tool from non-existent v4.1.2 to actual latest v4.1.1
- Add correct SHA256 checksum verification
- Fixes the publish workflow failure

## Issue
The publish workflow was failing because v4.1.2 doesn't exist yet. The latest version is v4.1.1.

## Testing
- Downloaded and verified the checksum locally
- Workflow should now complete successfully