### PR TITLE
chore: bump version to 0.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-claude",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-claude",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-claude",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Claude Code setup that just works. Bootstrap every project with agents, hooks, commands, and smart permissions. One command, zero headaches.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- Bump package version to 0.1.11
- Update package-lock.json

## Release
Ready for v0.1.11 tag and release after merge.