### PR TITLE
chore: add PAT support to OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -196,7 +196,7 @@ jobs:
         uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.3.2
         with:
           tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           body: |
             ## 🚀 Release ${{ github.ref_name }}
             

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           publish_results: true
 
       - name: "Upload artifact"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2025-09-07
+
+### Security
+
+- **OpenSSF Scorecard**: Added PAT support for branch protection verification
+- **Workflow Enhancement**: Scorecard workflow now uses dedicated token for full security analysis
+
+### Technical
+
+- Added `repo_token` parameter to Scorecard action for admin-level checks
+- Enables complete branch protection scoring in OpenSSF Scorecard
+
 ## [0.1.11] - 2025-09-07
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -29,5 +29,5 @@ keywords:
   - "productivity"
 license: MIT
 license-url: "https://github.com/RMNCLDYO/create-claude/blob/main/LICENSE"
-version: "0.1.9"
+version: "0.1.12"
 date-released: "2025-09-07"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-claude",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-claude",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-claude",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Claude Code setup that just works. Bootstrap every project with agents, hooks, commands, and smart permissions. One command, zero headaches.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- Add PAT support to OpenSSF Scorecard for branch protection verification
- Bump version to 0.1.12
- Update CHANGELOG.md

## Changes
The Scorecard workflow now uses `SCORECARD_TOKEN` to enable full security analysis including branch protection checks.

## Prerequisites
`SCORECARD_TOKEN` secret has been added to the repository with `repo` scope.