### PR TITLE
fix: normalize bin paths and add CODEOWNERS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.13] - 2025-09-07
+
+### Fixed
+
+- **NPM Warnings**: Normalized bin paths to resolve npm publish warnings about cleaned script names
+- **Package Configuration**: Applied `npm pkg fix` to resolve bin path formatting issues
+
+### Security
+
+- **Code Ownership**: Added CODEOWNERS file for better code review practices and accountability
+- **Branch Protection**: Enhanced OpenSSF Scorecard rating with code owner requirements
+- **Review Process**: Established clear ownership structure for all repository files
+
+### Technical
+
+- Removed leading `./` from bin paths in package.json per npm best practices
+- CODEOWNERS file covers all critical paths including source, docs, CI/CD, and security files
+- Improved repository governance for future contributions
+
 ## [0.1.12] - 2025-09-07
 
 ### Security

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,27 @@
+# CODEOWNERS for create-claude
+# This file defines code ownership for automatic review requests
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global owner for all files
+* @RMNCLDYO
+
+# Source code
+/src/ @RMNCLDYO
+*.js @RMNCLDYO
+*.ts @RMNCLDYO
+*.json @RMNCLDYO
+
+# Configuration and templates
+/.claude/ @RMNCLDYO
+/templates/ @RMNCLDYO
+
+# Documentation
+*.md @RMNCLDYO
+/docs/ @RMNCLDYO
+
+# CI/CD and workflows
+/.github/ @RMNCLDYO
+
+# Security-sensitive files
+/SECURITY.md @RMNCLDYO
+/.github/workflows/ @RMNCLDYO

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "./cli": "./dist/cli.js"
   },
   "bin": {
-    "create-claude": "./dist/cli.js",
-    "cld": "./dist/cli.js"
+    "create-claude": "dist/cli.js",
+    "cld": "dist/cli.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Changes

1. Normalized bin paths in package.json to resolve npm publish warnings
2. Added CODEOWNERS file for better code review practices

## Technical Details

### Package.json fixes
- Removed leading `./` from bin paths per npm best practices
- Fixes warning: `npm warn publish 'bin[create-claude]' script name was cleaned`
- Applied via `npm pkg fix` command

### CODEOWNERS addition
- Defines code ownership for automatic review requests
- Improves OpenSSF Scorecard branch protection score
- Ensures consistent review practices even for solo projects

## Testing

- Package will be validated in CI/CD pipeline
- No functional changes, only configuration improvements